### PR TITLE
fix deprecation warning  using bare variables

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -10,14 +10,14 @@
   copy:
     src: 'filters/{{ item }}.conf'
     dest: '{{ fail2ban_filter_path }}/{{ item }}.conf'
-  with_items: fail2ban_local_filters.stdout_lines|intersect(fail2ban_jails.keys())
+  with_items: "{{ fail2ban_local_filters.stdout_lines | intersect(fail2ban_jails.keys()) }}"
   notify: restart_fail2ban
 
 - name: copy custom actions
   copy:
     src: 'actions/{{ item }}'
     dest: '{{ fail2ban_action_path }}/{{ item }}'
-  with_items: fail2ban_actions
+  with_items: "{{ fail2ban_actions }}"
   notify: restart_fail2ban
 
 - name: set jail.local
@@ -32,12 +32,12 @@
     src: jail.conf.j2
     dest: '{{ fail2ban_jail_path }}/{{ item.key }}.conf'
     mode: 0644
-  with_dict: fail2ban_jails
+  with_dict: "{{ fail2ban_jails }}"
   notify: restart_fail2ban
 
 - name: remove custom jails
   file:
     path: '{{ fail2ban_jail_path }}/{{ item.key }}.conf'
     state: absent
-  with_items: remove_fail2ban_jails
+  with_items: "{{ remove_fail2ban_jails }}"
   notify: restart_fail2ban


### PR DESCRIPTION
Envelope variables with "{{ }}" in with_items.
