### PR TITLE
Several fixes, works on Fedora now, simplified package installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ fail2ban_path: path where Fail2Ban is installed on the remote host(s)
 fail2ban_filter_path: path where Fail2Ban stores all filters on the remote host(s)
 fail2ban_action_path: path where Fail2Ban stores all actions on the remote host(s)
 fail2ban_jail_path: path where Fail2Ban stores all custom jails on the remote host(s)
-fail2ban_pkg_state: indicates the package state; Allowed setting: installed, latest
-fail2ban_pkg_version: specify the specific package version you wish to install When specifying a version, the state will be forced to installed. When omitting the variable or leaving it empty it will install the package as specified by the state variable
+fail2ban_pkg_state: indicates the package state; Allowed setting: present, latest
+fail2ban_pkg_version: specify the specific package version you wish to install. When specifying a version, the state will be forced to present. When omitting the variable or leaving it empty it will install the package as specified by the state variable. Example value: '=0.8.13-1'
 fail2ban_service_state: indicates the service state; Allowed setting: started, stopped
 fail2ban_service_enabled: indicates if service needs to be enabled on boot; Allowed settings: yes, no
 fail2ban_config: is a dict that can hold all settings for your jail.local file

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ fail2ban_pkg_version: specify the specific package version you wish to install W
 fail2ban_service_state: indicates the service state; Allowed setting: started, stopped
 fail2ban_service_enabled: indicates if service needs to be enabled on boot; Allowed settings: yes, no
 fail2ban_config: is a dict that can hold all settings for your jail.local file
-fail2ban_jails: is a dict that can hold all filters that need to be configured in your jail.local file. The dict key will be used as section name and filter value. So make sure this matches. The filter key will also be used to check if there are any custom filters that need to be copied to the remote host(s). Your custom filters should be stored under files/filters
+fail2ban_jails: is a dict that can hold all jail configuration that goes in your jail.d directory (one jail per file). The dict key will be used as section name and filter value. So make sure this matches. The filter key will also be used to check if there are any custom filters that need to be copied to the remote host(s). Your custom filters should be stored under files/filters
 remove_fail2ban_jails: list of custom fail2ban jails defined in the jail.d folder that can be removed
 fail2ban_actions: holds a list with all custom actions that need to be copied to the remote host(s). Your custom actions should be stored under files/actions
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ fail2ban_path: /etc/fail2ban
 fail2ban_filter_path: /etc/fail2ban/filter.d
 fail2ban_action_path: /etc/fail2ban/action.d
 fail2ban_jail_path: /etc/fail2ban/jail.d
-fail2ban_pkg_state: installed
+fail2ban_pkg_state: present
 fail2ban_pkg_version:
 fail2ban_service_state: started
 fail2ban_service_enabled: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An ansible role for installing and configuring fail2ban. This role enables you to customize your local jail as well as configuring custom filters and actions.
   company: Netronix.be
   license: GPLv3
-  min_ansible_version: 1.8
+  min_ansible_version: 2.0
   platforms:
     - name: Ubuntu
       versions:
@@ -20,4 +20,3 @@ galaxy_info:
     - monitoring
     - networking
 dependencies: []
-

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -15,5 +15,5 @@
 - name: Install specific Fail2Ban version
   package:
     name: 'fail2ban{{ fail2ban_pkg_version }}'
-    state: '{{ fail2ban_pkg_state }}'
+    state: present
   when: fail2ban_pkg_version is not none

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,35 +1,19 @@
 ---
 
-- name: Debian | install specific Fail2Ban version
-  apt:
-    pkg: 'fail2ban={{ fail2ban_pkg_version }}'
-    state: installed
-    update_cache: yes
-    cache_valid_time: 3600
-  when: ansible_os_family == 'Debian' and fail2ban_pkg_version
-
-- name: Debian | install current/latest Fail2Ban version
-  apt:
-    pkg: fail2ban
-    state: '{{ fail2ban_pkg_state }}'
-    update_cache: yes
-    cache_valid_time: 3600
-  when: ansible_os_family == 'Debian' and not fail2ban_pkg_version
-
 - name: RedHat | install epel-release repository
   yum:
     name: epel-release
     state: installed
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
 
-- name: RedHat | install specific Fail2Ban version
-  yum:
-    name: 'fail2ban={{ fail2ban_pkg_version }}'
-    state: installed
-  when: ansible_os_family == 'RedHat' and fail2ban_pkg_version
-
-- name: RedHat | install current/latest Fail2Ban package
-  yum:
+- name: Install current/latest Fail2Ban version
+  package:
     name: fail2ban
     state: '{{ fail2ban_pkg_state }}'
-  when: ansible_os_family == 'RedHat' and not fail2ban_pkg_version
+  when: not fail2ban_pkg_version
+
+- name: Install specific Fail2Ban version
+  package:
+    name: 'fail2ban{{ fail2ban_pkg_version }}'
+    state: '{{ fail2ban_pkg_state }}'
+  when: fail2ban_pkg_version is not none


### PR DESCRIPTION
 made the package actually work on Fedora and maybe more distributions
- for RedHat systems: do not install epel-release when distro is Fedora (no epel needed there)
- use package module instead of apt/yum
  - this makes the tasks/package file more readable
  - this works for distributions with other package managers (e.g. Fedora with dnf)
  - package module requires ansible min version 2.0
  - state 'installed' is named 'present' now
- specify fail2ban_pkg_version like '=0.8.13-1' or '-0.8.13-1' instead of '0.8.13-1' because different distributions name the package versions differently
- clarified what the fail2ban_jails variable is good for
