### PR TITLE
Add support for Ubuntu Precise (12.04 LTS)

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - name: Debian
       versions:
         - jessie
+        - stretch
     - name: Fedora
       version:
         - all

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -28,6 +28,7 @@
     group: root
     mode: '0755'
     state: directory
+  when: ansible_distribution_release != 'precise'
 
 - name: set custom jails
   template:
@@ -36,6 +37,7 @@
     mode: 0644
   with_dict: '{{ fail2ban_jails }}'
   notify: restart_fail2ban
+  when: ansible_distribution_release != 'precise'
 
 - name: remove custom jails
   file:
@@ -43,3 +45,4 @@
     state: absent
   with_items: '{{ remove_fail2ban_jails }}'
   notify: restart_fail2ban
+  when: ansible_distribution_release != 'precise'

--- a/templates/jail.local.j2
+++ b/templates/jail.local.j2
@@ -6,3 +6,18 @@
 {% for param, value in fail2ban_config.items() %}
 {{ param }} = {{ value }}
 {% endfor %}
+
+{% if ansible_distribution_release == 'precise' %}
+{% for jail_name, jail_info in fail2ban_jails.iteritems() %}
+{% if jail_name not in remove_fail2ban_jails %}
+[{{ jail_name }}]
+
+filter = {{ jail_info.filter | default(jail_name) }}
+{% for key, value in jail_info.iteritems() if not key == 'filter' %}
+{{ key }} = {{ value }}
+{% endfor %}
+
+
+{% endif %}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Ubuntu Precise comes with Fail2Ban 0.8.6, which does not support **jail.d** directory for custom jails.

Those jails should be defined in jail.local, so I add them in that file when the OS is Ubuntu Precise. Otherwise, the jail.d directory is used.

I also tested the role on Debian Stretch, so I added it on the meta file.

Regards
Cristian