### PR TITLE
Add labels to loops

### DIFF
--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -4,6 +4,8 @@
     src: '{{ item }}'
     dest: '{{ fail2ban_filter_path }}/{{ item | basename }}'
   with_fileglob: "{{ fail2ban_upload_filters_path }}/*.conf"
+  loop_control:
+    label: "{{ item | basename }}"
   notify: restart_fail2ban
 
 - name: copy custom actions
@@ -11,6 +13,8 @@
     src: '{{ item }}'
     dest: '{{ fail2ban_action_path }}/{{ item | basename}}'
   with_fileglob: "{{ fail2ban_upload_actions_path }}/*"
+  loop_control:
+    label: "{{ item | basename }}"
   when: (item | basename) in fail2ban_actions
   notify: restart_fail2ban
 
@@ -36,6 +40,8 @@
     dest: '{{ fail2ban_jail_path }}/{{ item.key }}.conf'
     mode: 0644
   with_dict: '{{ fail2ban_jails }}'
+  loop_control:
+    label: "{{ item.key }}"
   notify: restart_fail2ban
   when: ansible_distribution_release != 'precise'
 
@@ -44,5 +50,7 @@
     path: '{{ fail2ban_jail_path }}/{{ item.key }}.conf'
     state: absent
   with_items: '{{ remove_fail2ban_jails }}'
+  loop_control:
+    label: "{{ item.key }}"
   notify: restart_fail2ban
   when: ansible_distribution_release != 'precise'


### PR DESCRIPTION
Since Ansible 2.2 one can set a **label** property to the loops.

This property overrides the output of the item on screen and on the logs, making them shorter an more readable.

From Ansible Docs:

```
When using complex data structures for looping the display might get a bit too “busy”, this is where the C(label) directive comes to help:
...
This will now display just the ‘label’ field instead of the whole structure per ‘item’, it defaults to ‘”{{item}}”’ to display things as usual.
```
