### PR TITLE
Update syntax for Ansible 2.4

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An ansible role for installing and configuring fail2ban. This role enables you to customize your local jail as well as configuring custom filters and actions.
   company: Netronix.be
   license: GPLv3
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 
-- include: package.yml
+- import_tasks: package.yml
   tags: package
 
-- include: configuration.yml
+- import_tasks: configuration.yml
   tags: configuration
 
 - name: start/stop fail2ban service


### PR DESCRIPTION
Since Ansible 2.4, the syntax for role and tasks include has been modified [0].

The old **include** syntax still works, but it throws a **deprecated** warning.

This commit update the syntax to be compatible with Ansible 2.4. But it's not backwards compatible.

[0] https://docs.ansible.com/ansible/latest/playbooks_reuse.html